### PR TITLE
Change folder for surge command to ./dist

### DIFF
--- a/packages/vite-app-ts/package.json
+++ b/packages/vite-app-ts/package.json
@@ -9,7 +9,7 @@
     "serve": "vite preview",
     "lint": "eslint --config ./.eslintrc --ignore-path ./.eslintignore ./src/**/*",
     "ipfs": "node ./scripts/ipfs.js",
-    "surge": "surge ./build",
+    "surge": "surge ./dist",
     "s3": "node ./scripts/s3.js",
     "ship": "yarn surge",
     "dev:link:components": "yalc link eth-components",


### PR DESCRIPTION
The folder for the `yarn surge` command seems to be wrong, as `yarn build` generates the build in the `dist` folder