### PR TITLE
Use chainId from providersConfig when loading contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ yarn deploy
 
 # Checkpoint 4: 🚢 Ship it! 🚁
 
-> ✏️ Edit the `TARGET_NETWORK_INFO` in `appConfig.ts` (in `packages/vite-app-ts/src/config`) to be the public network where you deployed your smart contract.
+> ✏️ Edit the `TARGET_NETWORK_INFO` in `providersConfig.ts` (in `packages/vite-app-ts/src/config`) to be the public network where you deployed your smart contract.
 
 ![image](https://user-images.githubusercontent.com/46639943/149599234-55921640-e677-42ca-a4a7-ab1fbca36ec4.png)
 

--- a/packages/vite-app-ts/src/app/routes/your-collectibles/YourCollectibles.tsx
+++ b/packages/vite-app-ts/src/app/routes/your-collectibles/YourCollectibles.tsx
@@ -1,6 +1,7 @@
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { FC, useEffect, useState } from 'react';
 import { YourCollectible } from '~~/generated/contract-types';
+import { targetNetworkInfo } from '~~/config/providersConfig';
 import { useAppContracts } from '~~/app/routes/main/hooks/useAppContracts';
 import { useContractLoader, useContractReader } from 'eth-hooks';
 import { useEthersContext } from 'eth-hooks/context';
@@ -35,7 +36,7 @@ export const YourCollectibles: FC<IYourCollectibleProps> = (props: IYourCollecti
   const ethersContext = useEthersContext();
   const appContractConfig = useAppContracts();
   const readContracts = useContractLoader(appContractConfig);
-  const writeContracts = useContractLoader(appContractConfig, ethersContext?.signer);
+  const writeContracts = useContractLoader(appContractConfig, ethersContext?.signer, targetNetworkInfo.chainId);
   const { mainnetProvider, blockExplorer, tx } = props;
 
   const YourCollectibleRead = readContracts['YourCollectible'] as YourCollectible;
@@ -102,12 +103,12 @@ export const YourCollectibles: FC<IYourCollectibleProps> = (props: IYourCollecti
         console.log(' 🍾 Transaction ' + update.hash + ' finished!');
         console.log(
           ' ⛽️ ' +
-            update.gasUsed +
-            '/' +
-            (update.gasLimit || update.gas) +
-            ' @ ' +
-            parseFloat(update.gasPrice) / 1000000000 +
-            ' gwei'
+          update.gasUsed +
+          '/' +
+          (update.gasLimit || update.gas) +
+          ' @ ' +
+          parseFloat(update.gasPrice) / 1000000000 +
+          ' gwei'
         );
       }
     });


### PR DESCRIPTION
Use chainId from providersConfig when loading contract: When creating the writeContract we need to include the ChanId, otherwise it's trying to connect to localhost.

Adjust README file reference: reference to appConfig file doesn't exist. Correct file it providersConfig