### PR TITLE
challenge-0 move initial commands to match text & js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,14 @@ yarn chain
 
 ```sh
 cd challenge-0-simple-nft
-yarn deploy
+yarn start
 ```
 
 > in a third terminal window, 🛰 deploy your contract:
 
 ```sh
 cd challenge-0-simple-nft
-yarn start
+yarn deploy
 ```
 
 > You can `yarn deploy --reset` to deploy a new contract any time.


### PR DESCRIPTION
Swaps `yarn run` and `yarn deploy` to match the text description as well as the javascript challenge version