### PR TITLE
README - Insert hardhat/console.sol instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ uint256 public constant threshold = 1 ether;
 💸 Need more funds from the faucet?  Enter your frontend address into the wallet to get as much as you need!
 ![Wallet_Medium](https://user-images.githubusercontent.com/12072395/159990402-d5535875-f1eb-4c75-86a7-6fbd5e6cbe5f.png)
 
+✏ Need to troubleshoot your code?  If you import `hardhat/console.sol` to your contract, you can call `console.log()` right in your Solidity code.  The output will appear in your `yarn chain` terminal.
+
 #### 🥅 Goals
 
 - [ ] Do you see the balance of the `Staker` contract go up when you `stake()`?


### PR DESCRIPTION
Add instructions on importing hardhat/console.sol and calling console/log() for troubleshooting purposes.