### PR TITLE
fix references to frontend and contract commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,14 @@ yarn chain
 
 ```sh
 cd challenge-0-simple-nft
-yarn deploy
+yarn start
 ```
 
 > in a third terminal window, 🛰 deploy your contract:
 
 ```sh
 cd challenge-0-simple-nft
-yarn start
+yarn deploy
 ```
 
 > You can `yarn deploy --reset` to deploy a new contract any time.


### PR DESCRIPTION
They are flipped. Seems correct on the JS one: https://github.com/scaffold-eth/scaffold-eth-challenges/blob/challenge-0-simple-nft/README.md