### PR TITLE
Issue fix #50 - Remove execute call from withdrawal test

### DIFF
--- a/packages/hardhat-ts/test/challenge-1.ts
+++ b/packages/hardhat-ts/test/challenge-1.ts
@@ -120,10 +120,6 @@ describe("🚩 Challenge 1: 🥩 Decentralized Staking App", function () {
           await network.provider.send("evm_increaseTime", [3600])
           await network.provider.send("evm_mine")
 
-          console.log('\t'," 🎉 calling execute")
-          const execResult = await stakerContract.execute();
-          console.log('\t'," 🏷  execResult: ",execResult.hash)
-
           const result = await exampleExternalContract.completed()
           console.log('\t'," 🥁 complete should be false: ",result)
           expect(result).to.equal(false);


### PR DESCRIPTION
Removes failing test despite the contract fulfilling the criteria.
[Issue outlined here](https://github.com/scaffold-eth/scaffold-eth-typescript-challenges/issues/50).