### PR TITLE
Challenge 2 token vendor

### DIFF
--- a/packages/hardhat-ts/deploy/01_deploy_vendor.ts
+++ b/packages/hardhat-ts/deploy/01_deploy_vendor.ts
@@ -13,24 +13,24 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironmentExtended) => {
 
   // Todo: deploy the vendor
 
-  // await deploy('Vendor', {
-  //   // Learn more about args here: https://www.npmjs.com/package/hardhat-deploy#deploymentsdeploy
-  //   from: deployer,
-  //   args: [yourToken.address],
-  //   log: true,
-  // });
+  await deploy('Vendor', {
+    // Learn more about args here: https://www.npmjs.com/package/hardhat-deploy#deploymentsdeploy
+    from: deployer,
+    args: [yourToken.address],
+    log: true,
+  });
 
-  // const vendor = await ethers.getContract("Vendor", deployer);
+  const vendor = await ethers.getContract("Vendor", deployer);
 
   // Todo: transfer the tokens to the vendor
-  // console.log("\n 🏵  Sending all 1000 tokens to the vendor...\n");
+  console.log("\n 🏵  Sending all 1000 tokens to the vendor...\n");
 
-  // await yourToken.transfer(
-  //   vendor.address,
-  //   ethers.utils.parseEther("1000")
-  // );
+  await yourToken.transfer(
+    vendor.address,
+    ethers.utils.parseEther("1000")
+  );
 
-  // await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");
+  await vendor.transferOwnership("**YOUR FRONTEND ADDRESS**");
 };
 export default func;
 func.tags = ['Vendor'];

--- a/packages/hardhat-ts/hardhat.config.ts
+++ b/packages/hardhat-ts/hardhat.config.ts
@@ -4,6 +4,10 @@
 // This adds support for typescript paths mappings
 import 'tsconfig-paths/register';
 
+// let us use the .env file
+import * as dotenv from 'dotenv';
+dotenv.config();
+
 import { Signer, utils } from 'ethers';
 import '@typechain/hardhat';
 import '@nomiclabs/hardhat-waffle';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,6 +1767,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@scaffold-eth/typescript@workspace:."
   dependencies:
+    dotenv: ^16.0.1
     eslint: ^7.32.0
     prettier: ^2.4.1
     react: ^17.0.2


### PR DESCRIPTION
Adding 'dotenv' to yarn.lock
And importing 'dotenv' in hardhat.config.ts
Uncommented the deployment of 'Vendor' in the deployment scripts